### PR TITLE
Added "Model Units" as default export unit option.

### DIFF
--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -189,7 +189,6 @@ module CommunityExtensions
           formats_translated.join('|')
         ]
         defaults = [
-          #STL.translate(read_setting('export_units', model_units())),
           STL.translate(read_setting('export_units', 'Model Units')),
           STL.translate(read_setting('stl_format', 'ASCII'))
         ]


### PR DESCRIPTION
Fixes #71

Added 'Model Units' as an option to Units dialog. 'Model Units' is default units. Selecting 'Model Units' always exports in the current model's units. 'Model Units' option persists until another unit option is selected. 
