### PR TITLE
Fixes #114 - ignore hidden geometry on export

### DIFF
--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -68,6 +68,7 @@ module CommunityExtensions
 
       def self.find_faces(file, entities, facet_count, scale, tform)
         entities.each do |entity|
+          next if entity.hidden? || !entity.layer.visible?
           if entity.is_a?(Sketchup::Face)
             facet_count += write_face(file, entity, scale, tform)
           elsif entity.is_a?(Sketchup::Group) ||


### PR DESCRIPTION
Simply does not process entities that are hidden, or which are on an invisible Layer.
