### PR TITLE
Bug/mirrored instances

### DIFF
--- a/src/sketchup-stl.rb
+++ b/src/sketchup-stl.rb
@@ -50,7 +50,7 @@ module CommunityExtensions
       'This is an open source project sponsored by the SketchUp team. More ' <<
       'info and updates at https://github.com/SketchUp/sketchup-stl'
     )
-    extension.version = '2.1.4'
+    extension.version = '2.1.5'
     extension.copyright = '2012-2014 Trimble Navigation, ' <<
       'released under Apache 2.0'
     extension.creator = 'J. Foltz, N. Bromham, K. Shroeder, SketchUp Team'

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -219,10 +219,9 @@ module CommunityExtensions
       # to the .stl file.
       def self.get_vertex_order(positions, face_normal)
         calculated_normal = (positions[1] - positions[0]).cross( (positions[2] - positions[0]) )
-        calculated_normal.normalize!
         order = [0, 1, 2]
-        order.reverse! if calculated_normal != face_normal
-        return order
+        order.reverse! if !calculated_normal.samedirection?(face_normal)
+        order
       end
 
       def self.do_options

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -212,13 +212,16 @@ module CommunityExtensions
         factor
       end
 
-      def self.get_vertex_order(vertices, normal)
-        n = (vertices[1] - vertices[0]).cross( (vertices[2] - vertices[0]) )
-        n.normalize!
+      # Flipped insances in SketchUp may not follow the right-hand rule,
+      # but the STL format expects vertices ordered by the right-hand rule.
+      # If the SketchUp::Face normal does not match the normal calculated
+      # using the right-hand rule, then reverse the vertex order written
+      # to the .stl file.
+      def self.get_vertex_order(positions, face_normal)
+        calculated_normal = (positions[1] - positions[0]).cross( (positions[2] - positions[0]) )
+        calculated_normal.normalize!
         order = [0, 1, 2]
-        if n != normal
-          order = [0, 2, 1]
-        end
+        order.reverse! if calculated_normal != face_normal
         return order
       end
 

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -220,7 +220,7 @@ module CommunityExtensions
       def self.get_vertex_order(positions, face_normal)
         calculated_normal = (positions[1] - positions[0]).cross( (positions[2] - positions[0]) )
         order = [0, 1, 2]
-        order.reverse! if !calculated_normal.samedirection?(face_normal)
+        order.reverse! if calculated_normal.dot(face_normal) < 0
         order
       end
 

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -107,7 +107,6 @@ module CommunityExtensions
         polygons = mesh.polygons
         polygons.each do |polygon|
           if (polygon.length == 3)
-            #norm = mesh.normal_at(polygon[0].abs).normalize
             file.write("facet normal #{normal.x} #{normal.y} #{normal.z}\n")
             file.write("  outer loop\n")
             for j in vertex_order do


### PR DESCRIPTION
Correct the exported vertex order (winding) for flipped instances. 