### PR TITLE
standardize file headers

### DIFF
--- a/src/sketchup-stl.rb
+++ b/src/sketchup-stl.rb
@@ -1,12 +1,14 @@
-# Copyright 2012-2014 Trimble Navigation Ltd.
+# Copyright 2012-2015 Trimble Navigation Ltd.
 #
 # License: The MIT License (MIT)
 #
 # A SketchUp Ruby Extension that adds STL (STereoLithography) file format
 # import and export. More info at https://github.com/SketchUp/sketchup-stl
+#
+# Sketchup-stl Extension
 
-require 'sketchup.rb'
-require 'extensions.rb'
+require 'sketchup'
+require 'extensions'
 
 module CommunityExtensions
   module STL

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -1,10 +1,13 @@
-# SketchUp to DXF STL Converter
-# Last edited: February 18, 2011
-# Authors: Nathan Bromham, Konrad Shroeder (http://www.guitar-list.com/)
+# Copyright 2012-2015 Trimble Navigation Ltd.
 #
-# License: Apache License, Version 2.0
+# License: The MIT License (MIT)
+#
+# A SketchUp Ruby Extension that adds STL (STereoLithography) file format
+# import and export. More info at https://github.com/SketchUp/sketchup-stl
+#
+# Exporter
 
-require 'sketchup.rb'
+require 'sketchup'
 
 module CommunityExtensions
   module STL

--- a/src/sketchup-stl/importer.rb
+++ b/src/sketchup-stl/importer.rb
@@ -1,8 +1,11 @@
-# jf_stl_importer.rb - Imports ascii and binary .stl file in SketchUp
+# Copyright 2012-2015 Trimble Navigation Ltd.
 #
-# Copyright (C) 2010 Jim Foltz (jim.foltz@gmail.com)
+# License: The MIT License (MIT)
 #
-# License: Apache License, Version 2.0
+# A SketchUp Ruby Extension that adds STL (STereoLithography) file format
+# import and export. More info at https://github.com/SketchUp/sketchup-stl
+#
+# Importer
 
 require 'sketchup'
 

--- a/src/sketchup-stl/loader.rb
+++ b/src/sketchup-stl/loader.rb
@@ -1,8 +1,13 @@
-# Copyright 2012 Trimble Navigation Ltd.
+# Copyright 2012-2015 Trimble Navigation Ltd.
 #
-# License: Apache License, Version 2.0
+# License: The MIT License (MIT)
+#
+# A SketchUp Ruby Extension that adds STL (STereoLithography) file format
+# import and export. More info at https://github.com/SketchUp/sketchup-stl
+#
+# Loader
 
-require 'sketchup.rb'
+require 'sketchup'
 
 module CommunityExtensions
   module STL

--- a/src/sketchup-stl/translator.rb
+++ b/src/sketchup-stl/translator.rb
@@ -1,6 +1,11 @@
-# Translator - the class formerly known as LanguageHandler2
+# Copyright 2012-2015 Trimble Navigation Ltd.
 #
-# License: Apache License, Version 2.0
+# License: The MIT License (MIT)
+#
+# A SketchUp Ruby Extension that adds STL (STereoLithography) file format
+# import and export. More info at https://github.com/SketchUp/sketchup-stl
+#
+# Translator - the class formerly known as LanguageHandler2
 
 require 'sketchup'
 

--- a/src/sketchup-stl/utils.rb
+++ b/src/sketchup-stl/utils.rb
@@ -1,3 +1,12 @@
+# Copyright 2012-2015 Trimble Navigation Ltd.
+#
+# License: The MIT License (MIT)
+#
+# A SketchUp Ruby Extension that adds STL (STereoLithography) file format
+# import and export. More info at https://github.com/SketchUp/sketchup-stl
+#
+# Utilities
+
 module CommunityExtensions
   module STL
     module Utils

--- a/src/sketchup-stl/webdialog_extensions.rb
+++ b/src/sketchup-stl/webdialog_extensions.rb
@@ -1,3 +1,12 @@
+# Copyright 2012-2015 Trimble Navigation Ltd.
+#
+# License: The MIT License (MIT)
+#
+# A SketchUp Ruby Extension that adds STL (STereoLithography) file format
+# import and export. More info at https://github.com/SketchUp/sketchup-stl
+#
+# WebDialog Extensions
+
 require 'sketchup'
 
 module CommunityExtensions


### PR DESCRIPTION
Fix for #116 cleanup headers

* Updated copyright year to 2015
* Changed references from Apache License to MIT license.
* Standardized headers.
* Standardized `require 'sketchup'`

