### PR TITLE
Hotfix/empty export warning

### DIFF
--- a/src/sketchup-stl.rb
+++ b/src/sketchup-stl.rb
@@ -52,7 +52,7 @@ module CommunityExtensions
       'This is an open source project sponsored by the SketchUp team. More ' <<
       'info and updates at https://github.com/SketchUp/sketchup-stl'
     )
-    extension.version = '2.1.6'
+    extension.version = '2.1.8'
     extension.copyright = '2012-2015 Trimble Navigation, ' <<
       'released under the MIT License'
     extension.creator = 'J. Foltz, N. Bromham, K. Shroeder, SketchUp Team'

--- a/src/sketchup-stl.rb
+++ b/src/sketchup-stl.rb
@@ -52,7 +52,7 @@ module CommunityExtensions
       'This is an open source project sponsored by the SketchUp team. More ' <<
       'info and updates at https://github.com/SketchUp/sketchup-stl'
     )
-    extension.version = '2.1.8-jf'
+    extension.version = '2.1.6'
     extension.copyright = '2012-2015 Trimble Navigation, ' <<
       'released under the MIT License'
     extension.creator = 'J. Foltz, N. Bromham, K. Shroeder, SketchUp Team'

--- a/src/sketchup-stl.rb
+++ b/src/sketchup-stl.rb
@@ -52,7 +52,7 @@ module CommunityExtensions
       'This is an open source project sponsored by the SketchUp team. More ' <<
       'info and updates at https://github.com/SketchUp/sketchup-stl'
     )
-    extension.version = '2.1.6'
+    extension.version = '2.1.8-jf'
     extension.copyright = '2012-2015 Trimble Navigation, ' <<
       'released under the MIT License'
     extension.creator = 'J. Foltz, N. Bromham, K. Shroeder, SketchUp Team'

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -364,8 +364,8 @@ module CommunityExtensions
       # show the export dialog.
       def self.main
         if Sketchup.active_model.active_entities.length == 0
-          msg = "SketchUp STL Exporter:\n\n" +
-            STL.translate("The model is empty - there is nothing to export.")
+          msg = "SketchUp STL Exporter:\n\n"
+          msg << STL.translate("The model is empty - there is nothing to export.")
           UI.messagebox(msg, MB_OK)
         else
           do_options()

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -242,7 +242,7 @@ module CommunityExtensions
         else
           export_ents = Sketchup.active_model.active_entities
         end
-        return export_ents
+        export_ents
       end
 
 

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -261,7 +261,7 @@ module CommunityExtensions
 
         # Row 1 Export Selected
         chk_selection = SKUI::Checkbox.new(
-          'Export selected geometry only.',
+          'Export only current selection',
           OPTIONS['selection_only']
         )
         chk_selection.position(col[1], row[1])

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -64,7 +64,7 @@ module CommunityExtensions
             @write_face = method(:write_face_ascii)
          end
          scale = scale_factor(options['export_units'])
-         write_header(file, model_name(), options['stl_format'])
+         write_header(file, model_name, options['stl_format'])
          facet_count = find_faces(file, export_entities, 0, scale, Geom::Transformation.new)
          write_footer(file, facet_count, model_name(), options['stl_format'])
       end

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -40,13 +40,13 @@ module CommunityExtensions
 
       def self.select_export_file
         title_template  = STL.translate('%s file location')
-        default_filename = "#{model_name()}.#{file_extension()}"
+        default_filename = "#{model_name}.#{file_extension}"
         dialog_title = sprintf(title_template, default_filename)
         directory = nil
         filename = UI.savepanel(dialog_title, directory, default_filename)
         # Ensure the file has a file extensions if the user omitted it.
         if filename && File.extname(filename).empty?
-          filename = "#{filename}.#{file_extension()}"
+          filename = "#{filename}.#{file_extension}"
         end
         filename
       end
@@ -66,7 +66,7 @@ module CommunityExtensions
          scale = scale_factor(options['export_units'])
          write_header(file, model_name, options['stl_format'])
          facet_count = find_faces(file, export_entities, 0, scale, Geom::Transformation.new)
-         write_footer(file, facet_count, model_name(), options['stl_format'])
+         write_footer(file, facet_count, model_name, options['stl_format'])
       end
 
       def self.find_faces(file, entities, facet_count, scale, tform)
@@ -194,7 +194,7 @@ module CommunityExtensions
 
       def self.scale_factor(unit_key)
         if unit_key == 'Model Units'
-          selected_key = model_units()
+          selected_key = model_units
         else
           selected_key = unit_key
         end
@@ -368,7 +368,7 @@ module CommunityExtensions
           msg << STL.translate("The model is empty - there is nothing to export.")
           UI.messagebox(msg, MB_OK)
         else
-          do_options()
+          do_options
         end
       end
 
@@ -384,11 +384,11 @@ module CommunityExtensions
         # (i) The menu_index argument isn't supported by older versions.
         if Sketchup::Menu.instance_method(:add_item).arity == 1
           item = UI.menu('File').add_item(STL.translate('Export STL...')) {
-            main()
+            main
           }
         else
           item = UI.menu('File').add_item(STL.translate('Export STL...'), insert_index) {
-            main()
+            main
           }
         end
         file_loaded(self.name)

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -330,6 +330,7 @@ module CommunityExtensions
           write_setting('stl_format'     , OPTIONS['stl_format'])
           write_setting('selection_only' , OPTIONS['selection_only'])
 
+          control.window.close
           export_entities = get_export_entities()
           if export_entities
              path = select_export_file()

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -330,9 +330,9 @@ module CommunityExtensions
           write_setting('stl_format'     , OPTIONS['stl_format'])
           write_setting('selection_only' , OPTIONS['selection_only'])
           control.window.close
-          export_entities = get_export_entities()
+          export_entities = get_export_entities
           if export_entities
-             path = select_export_file()
+             path = select_export_file
              begin
                 export(path, export_entities, OPTIONS) unless path.nil?
              rescue => exc

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -225,6 +225,7 @@ module CommunityExtensions
         order
       end
 
+      # Return model.active_entites, selection, or nil
       def self.get_export_entities
         export_ents = nil
         if OPTIONS['selection_only']
@@ -233,7 +234,7 @@ module CommunityExtensions
           else
             msg = "SketchUp STL Exporter:\n\n"
             msg << "You have chosen \"Export only current selection\", but nothing is selected."
-            msg << "\nWould you like to export the entire model?"
+            msg << "\n\nWould you like to export the entire model?"
             if UI.messagebox(msg, MB_YESNO) == IDYES
               export_ents = Sketchup.active_model.active_entities
             end
@@ -325,11 +326,9 @@ module CommunityExtensions
         # Export and Cancel Buttons
         #
         btn_export = SKUI::Button.new('Export') { |control|
-
           write_setting('export_units'   , OPTIONS['export_units'])
           write_setting('stl_format'     , OPTIONS['stl_format'])
           write_setting('selection_only' , OPTIONS['selection_only'])
-
           control.window.close
           export_entities = get_export_entities()
           if export_entities
@@ -342,11 +341,8 @@ module CommunityExtensions
                 msg << exc.message << "\n"
                 msg << exc.backtrace.join("\n")
                 UI.messagebox(msg, MB_MULTILINE)
-             ensure
-                control.window.close
              end
           end
-          control.window.close
         }
 
         btn_export.position(125, -5)
@@ -362,7 +358,9 @@ module CommunityExtensions
         window.show
       end # do_options
 
-      # Display a notice if the model is empty, else
+
+      # Main entry point via menu item.
+      # Display a message and exit if the model is empty, else
       # show the export dialog.
       def self.main
         if Sketchup.active_model.active_entities.length == 0

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -335,11 +335,11 @@ module CommunityExtensions
              path = select_export_file
              begin
                 export(path, export_entities, OPTIONS) unless path.nil?
-             rescue => exc
+             rescue => exception
                 msg = "SketchUp STL Exporter:\n"
                 msg << "An error occured during export.\n\n"
-                msg << exc.message << "\n"
-                msg << exc.backtrace.join("\n")
+                msg << exception.message << "\n"
+                msg << exception.backtrace.join("\n")
                 UI.messagebox(msg, MB_MULTILINE)
              end
           end

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -355,11 +355,11 @@ module CommunityExtensions
         # (i) The menu_index argument isn't supported by older versions.
         if Sketchup::Menu.instance_method(:add_item).arity == 1
           item = UI.menu('File').add_item(STL.translate('Export STL...')) {
-            do_options
+            main()
           }
         else
           item = UI.menu('File').add_item(STL.translate('Export STL...'), insert_index) {
-            do_options
+            main()
           }
         end
         file_loaded(self.name)

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -352,13 +352,6 @@ module CommunityExtensions
             do_options
           }
         end
-        UI.menu('File').set_validation_proc(item) do
-          if Sketchup.active_model.entities.length == 0
-            MF_GRAYED
-          else
-            MF_ENABLED
-          end
-        end
         file_loaded(self.name)
       end
 

--- a/src/sketchup-stl/exporter.rb
+++ b/src/sketchup-stl/exporter.rb
@@ -334,6 +334,16 @@ module CommunityExtensions
         window.show
       end # do_options
 
+      def self.main
+        if Sketchup.active_model.active_entities.length == 0
+          msg = "SketchUp STL Exporter\n\n" +
+            STL.translate("The model is empty - there is nothing to export.")
+          UI.messagebox(msg, MB_OK)
+        else
+          do_options()
+        end
+      end
+
       unless file_loaded?(self.name)
         # Pick menu indexes for where to insert the Export menu. These numbers
         # where picked when SketchUp 8 M4 was the latest version.


### PR DESCRIPTION
Fixes #159 

The STL Exporter would happily export a .stl file with no facets if the "Export selection only" option was checked but nothing in the model was actually selected. 

